### PR TITLE
Issue #3. Add method returning Single<T>

### DIFF
--- a/objectbox-rxjava/src/main/java/io/objectbox/rx/RxQuery.java
+++ b/objectbox-rxjava/src/main/java/io/objectbox/rx/RxQuery.java
@@ -145,7 +145,7 @@ public abstract class RxQuery {
                     @Override
                     public void onData(List<T> data) {
                         if (!emitter.isDisposed()) {
-                            if (data.get(0) != null) {
+                            if (!data.isEmpty()) {
                                 emitter.onSuccess(data.get(0));
                             } else {
                                 emitter.onError(new NullPointerException("Item not found"));


### PR DESCRIPTION
Returns first item as Single if any, else returns NPE onError.
To return the result of findFirst(), users must filter the query accordingly before passing it as a parameter.